### PR TITLE
docs: fix implementation file references across all ADRs

### DIFF
--- a/docs/adr/0003-tokenizer-based-detection.md
+++ b/docs/adr/0003-tokenizer-based-detection.md
@@ -137,12 +137,11 @@ Scores are per-detector and independent. The pipeline accumulates them via `Scor
 | `internal/layers/detection/sqli/patterns.go` | SQLi pattern definitions and scoring rules |
 | `internal/layers/detection/sqli/sqli.go` | Detector implementation, score thresholds |
 | `internal/layers/detection/xss/tokenizer.go` | HTML/JS tokenizer for XSS detection |
-| `internal/layers/detection/lfi/tokenizer.go` | Path traversal tokenizer (path separators, null bytes, URL encoding) |
-| `internal/layers/detection/cmdi/tokenizer.go` | Command injection tokenizer (pipes, redirects, metacharacters) |
-| `internal/layers/detection/xxe/tokenizer.go` | XML external entity tokenizer |
-| `internal/layers/detection/ssrf/tokenizer.go` | SSRF URL tokenizer (scheme validation, private IP detection) |
-| `internal/layers/detection/shared/patterns.go` | Shared pattern library (URL patterns, IP patterns) |
-| `ADR 0033` | Request Sanitizer — 9-step normalization before detection |
+| `internal/layers/detection/lfi/lfi.go` | LFI detector with sensitive path checking |
+| `internal/layers/detection/cmdi/cmdi.go` | Command injection detector with shell metacharacter patterns |
+| `internal/layers/detection/xxe/xxe.go` | XML external entity detector |
+| `internal/layers/detection/ssrf/ssrf.go` | SSRF URL detector with private IP checking |
+| `internal/layers/detection/detector.go` | Base detector interface and shared utilities |
 
 ## References
 

--- a/docs/adr/0004-pipeline-architecture.md
+++ b/docs/adr/0004-pipeline-architecture.md
@@ -195,7 +195,7 @@ Exclusion matching uses `ctx.NormalizedPath` when available (written by the Sani
 | `internal/engine/pipeline.go` | Pipeline struct, Execute(), AddLayer(), SetExclusions() |
 | `internal/engine/layer.go` | Layer interface, OrderedLayer struct, LayerResult, Action, Finding, LayerOrder constants (100–600, 16 defined) |
 | `internal/engine/context.go` | RequestContext struct, AcquireContext(), ReleaseContext() |
-| `internal/engine/scoring.go` | ScoreAccumulator, Add(), AddMultiple(), Total() |
+| `internal/engine/finding.go` | ScoreAccumulator, Add(), AddMultiple(), Total() |
 
 ## References
 

--- a/docs/adr/0005-react-dashboard.md
+++ b/docs/adr/0005-react-dashboard.md
@@ -160,9 +160,8 @@ The React dashboard (14 pages, all route through React Router SPA with SSE real-
 
 | File | Purpose |
 |------|---------|
-| `internal/dashboard/dashboard.go` | HTTP handler, embed.FS declaration, route wiring |
-| `internal/dashboard/api.go` | REST API handlers (events, stats, config) |
-| `internal/dashboard/sse.go` | SSE endpoint and event broadcaster |
+| `internal/dashboard/dashboard.go` | HTTP handler, embed.FS declaration, route wiring, SSE broadcaster |
+| `internal/dashboard/` | REST API handlers (events, stats, config, ai, config editor, routing graph) |
 | `internal/dashboard/ui/` | React 19 source (Vite project) |
 | `internal/dashboard/dist/` | Built React assets (embed.FS target) |
 | `Makefile` (`ui` target) | `cd internal/dashboard/ui && npm install && npm run build` |


### PR DESCRIPTION
## Summary

Fix implementation file references across multiple ADRs where listed files don't match actual codebase:

- **ADR 0003** (Tokenizer): Remove non-existent `tokenizer.go` entries for lfi/cmdi/xxe/ssrf; replace with actual detector file names (`lfi.go`, `cmdi.go`, `xxe.go`, `ssrf.go`). Remove non-existent `internal/layers/detection/shared/patterns.go`.
- **ADR 0004** (Pipeline): `scoring.go` → `finding.go` (ScoreAccumulator lives in `finding.go`, not `scoring.go`)
- **ADR 0005** (Dashboard): Merge `api.go` and `sse.go` into single `internal/dashboard/` entry (these files don't exist as separate files)

## Test plan

- [x] All referenced files verified against actual codebase
- [x] No references to non-existent files remain in updated ADRs
- [x] ADR format and rendering verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)