### PR TITLE
docs: fix remaining ADR implementation file references

### DIFF
--- a/docs/adr/0003-tokenizer-based-detection.md
+++ b/docs/adr/0003-tokenizer-based-detection.md
@@ -136,7 +136,7 @@ Scores are per-detector and independent. The pipeline accumulates them via `Scor
 | `internal/layers/detection/sqli/tokenizer.go` | SQL tokenizer (string literals, keywords, operators, comments) |
 | `internal/layers/detection/sqli/patterns.go` | SQLi pattern definitions and scoring rules |
 | `internal/layers/detection/sqli/sqli.go` | Detector implementation, score thresholds |
-| `internal/layers/detection/xss/tokenizer.go` | HTML/JS tokenizer for XSS detection |
+| `internal/layers/detection/xss/parser.go` | HTML/JS parser for XSS detection |
 | `internal/layers/detection/lfi/lfi.go` | LFI detector with sensitive path checking |
 | `internal/layers/detection/cmdi/cmdi.go` | Command injection detector with shell metacharacter patterns |
 | `internal/layers/detection/xxe/xxe.go` | XML external entity detector |

--- a/docs/adr/0006-multi-tenant-isolation.md
+++ b/docs/adr/0006-multi-tenant-isolation.md
@@ -147,7 +147,7 @@ The swap is a single atomic pointer assignment — no locking required for read 
 | `internal/engine/context.go` | `RequestContext.TenantID`, `RequestContext.TenantWAFConfig` |
 | `internal/config/config.go` | `VirtualHostConfig`, `TenantWAFConfig` structs |
 | `internal/config/findvh_test.go` | Virtual host → tenant resolution tests |
-| `internal/tenant/tenant.go` | Tenant registry, billing, rate tracking per tenant |
+| `internal/tenant/manager.go` | Tenant registry, billing, rate tracking per tenant |
 | `internal/engine/engine.go` | Tenant resolution at request entry (called once per request) |
 | `internal/layers/ratelimit/ratelimit.go` | Per-tenant rate limit bucket namespacing (`tenantID:key`) |
 | `internal/layers/ipacl/ipacl.go` | Per-tenant IP ban list namespacing |

--- a/docs/adr/0018-enhanced-bot-management.md
+++ b/docs/adr/0018-enhanced-bot-management.md
@@ -216,7 +216,7 @@ The enhanced features below are planned: `fingerprint/fingerprinter.go`, `biomet
 | `internal/layers/botdetect/biometric/detector.go` | Biometric summary parsing and scoring (planned) |
 | `internal/layers/botdetect/web/` | rDNS verification and ASN checking (planned) |
 | `internal/layers/botdetect/challenge/` | CAPTCHA challenge flow (planned: hcaptcha.go exists) |
-| `internal/layers/clientside/agent.js` | JS biometric/fingerprint collector (planned) |
+| `internal/layers/clientside/agent/agent.js` | JS biometric/fingerprint collector (planned) |
 | `internal/config/config.go` | `BotDetectionConfig` extensions |
 
 ## References


### PR DESCRIPTION
## Summary

Fix remaining ADR implementation file references:

- **ADR 0003**: `xss/tokenizer.go` → `xss/parser.go` — XSS uses a parser, not a tokenizer
- **ADR 0006**: `tenant/tenant.go` → `tenant/manager.go` — the tenant registry file is `manager.go`, not `tenant.go`
- **ADR 0018**: `clientside/agent.js` → `clientside/agent/agent.js` — consistent with planned structure in ADR 0021

## Test plan

- [x] All referenced files verified against actual codebase
- [x] No other broken references found in ADR corpus

🤖 Generated with [Claude Code](https://claude.com/claude-code)