### PR TITLE
fix(config): fix three serialization bugs in marshalInlineField

### DIFF
--- a/internal/config/serialize.go
+++ b/internal/config/serialize.go
@@ -96,6 +96,12 @@ func marshalField(b *strings.Builder, prefix, key string, fv reflect.Value, inde
 		fmt.Fprintf(b, "%s%s:\n", prefix, key)
 		marshalStruct(b, fv, fv.Type(), indent+1)
 
+	case reflect.Ptr:
+		if fv.IsNil() {
+			return
+		}
+		marshalField(b, prefix, key, fv.Elem(), indent)
+
 	case reflect.Interface:
 		if fv.IsNil() {
 			return
@@ -186,20 +192,55 @@ func marshalInlineField(b *strings.Builder, key string, fv reflect.Value, indent
 	case reflect.Bool:
 		fmt.Fprintf(b, "%s: %t\n", key, fv.Bool())
 	case reflect.Slice:
-		// For inline slices in sequence items, use flow style [a, b, c]
 		if fv.Len() == 0 {
 			return
 		}
-		if fv.Type().Elem().Kind() == reflect.String {
+		elemKind := fv.Type().Elem().Kind()
+		if elemKind == reflect.String {
+			// flow style [a, b, c]
 			var items []string
 			for i := range fv.Len() {
 				items = append(items, fv.Index(i).String())
 			}
 			fmt.Fprintf(b, "%s: [%s]\n", key, strings.Join(items, ", "))
+		} else if elemKind == reflect.Struct {
+			// Bug 2 fix: struct slices inside sequence items — block style
+			fmt.Fprintf(b, "%s:\n", key)
+			childPrefix := strings.Repeat("  ", indent)
+			for i := range fv.Len() {
+				elem := fv.Index(i)
+				et := elem.Type()
+				first := true
+				for j := range et.NumField() {
+					field := et.Field(j)
+					ftag := field.Tag.Get("yaml")
+					if ftag == "" || ftag == "-" {
+						continue
+					}
+					fieldVal := elem.Field(j)
+					if isZeroValue(fieldVal) {
+						continue
+					}
+					if first {
+						fmt.Fprintf(b, "%s- ", childPrefix)
+						marshalInlineField(b, ftag, fieldVal, indent+1)
+						first = false
+					} else {
+						fmt.Fprintf(b, "%s  ", childPrefix)
+						marshalInlineField(b, ftag, fieldVal, indent+1)
+					}
+				}
+			}
 		}
 	case reflect.Struct:
+		// Bug 1 fix: was indent, must be indent+1 so child fields are indented under the key
 		fmt.Fprintf(b, "%s:\n", key)
-		marshalStruct(b, fv, fv.Type(), indent)
+		marshalStruct(b, fv, fv.Type(), indent+1)
+	case reflect.Ptr:
+		// Bug 3 fix: handle pointer fields (e.g. *WAFConfig in VirtualHostConfig)
+		if !fv.IsNil() {
+			marshalInlineField(b, key, fv.Elem(), indent)
+		}
 	case reflect.Interface:
 		if !fv.IsNil() {
 			marshalInlineField(b, key, fv.Elem(), indent)
@@ -248,6 +289,8 @@ func isZeroValue(v reflect.Value) bool {
 			}
 		}
 		return true
+	case reflect.Ptr:
+		return v.IsNil()
 	case reflect.Interface:
 		return v.IsNil()
 	}

--- a/internal/config/serialize_test.go
+++ b/internal/config/serialize_test.go
@@ -136,3 +136,133 @@ func TestFormatDuration(t *testing.T) {
 		}
 	}
 }
+
+// TestMarshalYAML_UpstreamTargets verifies that Upstreams with nested Targets
+// and HealthCheck are fully serialized and survive a roundtrip.
+// Covers Bug 2 (struct slice in inline context) and Bug 1 (nested struct indentation).
+func TestMarshalYAML_UpstreamTargets(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Upstreams = []UpstreamConfig{
+		{
+			Name: "backend",
+			Targets: []TargetConfig{
+				{URL: "http://localhost:3000", Weight: 1},
+			},
+			HealthCheck: HealthCheckConfig{
+				Enabled:  true,
+				Interval: 30 * time.Second,
+				Path:     "/health",
+			},
+			LoadBalancer: "round_robin",
+		},
+	}
+
+	out := MarshalYAML(cfg)
+
+	if !strings.Contains(out, "targets:") {
+		t.Errorf("expected 'targets:' in output (Bug 2 regression); got:\n%s", out)
+	}
+	if !strings.Contains(out, "http://localhost:3000") {
+		t.Errorf("expected target URL in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "health_check:") {
+		t.Errorf("expected 'health_check:' in output; got:\n%s", out)
+	}
+
+	// Roundtrip: parse back and verify values (also catches Bug 1 indentation)
+	node, err := Parse([]byte(out))
+	if err != nil {
+		t.Fatalf("Parse error after marshal: %v\nYAML:\n%s", err, out)
+	}
+	cfg2 := DefaultConfig()
+	if err := PopulateFromNode(cfg2, node); err != nil {
+		t.Fatalf("PopulateFromNode error: %v", err)
+	}
+	if len(cfg2.Upstreams) != 1 {
+		t.Fatalf("expected 1 upstream after roundtrip, got %d", len(cfg2.Upstreams))
+	}
+	if len(cfg2.Upstreams[0].Targets) != 1 {
+		t.Fatalf("expected 1 target after roundtrip, got %d", len(cfg2.Upstreams[0].Targets))
+	}
+	if cfg2.Upstreams[0].Targets[0].URL != "http://localhost:3000" {
+		t.Errorf("target URL: got %q, want %q", cfg2.Upstreams[0].Targets[0].URL, "http://localhost:3000")
+	}
+	if !cfg2.Upstreams[0].HealthCheck.Enabled {
+		t.Error("expected health_check.enabled=true after roundtrip (Bug 1 regression)")
+	}
+}
+
+// TestMarshalYAML_VirtualHostRoutes verifies that VirtualHosts with nested
+// Routes are fully serialized and survive a roundtrip.
+// Covers Bug 2 (struct slice in inline context).
+func TestMarshalYAML_VirtualHostRoutes(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Upstreams = []UpstreamConfig{
+		{Name: "backend", Targets: []TargetConfig{{URL: "http://localhost:3000"}}},
+	}
+	cfg.VirtualHosts = []VirtualHostConfig{
+		{
+			Domains: []string{"api.example.com"},
+			Routes: []RouteConfig{
+				{Path: "/api", Upstream: "backend", Methods: []string{"GET", "POST"}},
+			},
+		},
+	}
+
+	out := MarshalYAML(cfg)
+
+	if !strings.Contains(out, "virtual_hosts:") {
+		t.Errorf("expected 'virtual_hosts:' in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "routes:") {
+		t.Errorf("expected 'routes:' in output (Bug 2 regression); got:\n%s", out)
+	}
+	if !strings.Contains(out, "/api") {
+		t.Errorf("expected route path '/api' in output; got:\n%s", out)
+	}
+
+	node, err := Parse([]byte(out))
+	if err != nil {
+		t.Fatalf("Parse error: %v\nYAML:\n%s", err, out)
+	}
+	cfg2 := DefaultConfig()
+	if err := PopulateFromNode(cfg2, node); err != nil {
+		t.Fatalf("PopulateFromNode error: %v", err)
+	}
+	if len(cfg2.VirtualHosts) != 1 {
+		t.Fatalf("expected 1 virtual host after roundtrip, got %d", len(cfg2.VirtualHosts))
+	}
+	if len(cfg2.VirtualHosts[0].Routes) != 1 {
+		t.Fatalf("expected 1 route after roundtrip, got %d", len(cfg2.VirtualHosts[0].Routes))
+	}
+	if cfg2.VirtualHosts[0].Routes[0].Path != "/api" {
+		t.Errorf("route path: got %q, want %q", cfg2.VirtualHosts[0].Routes[0].Path, "/api")
+	}
+}
+
+// TestMarshalYAML_VirtualHostWAFPointer verifies that the *WAFConfig pointer
+// field on VirtualHostConfig is serialized correctly.
+// Covers Bug 3 (missing reflect.Ptr case in marshalInlineField).
+func TestMarshalYAML_VirtualHostWAFPointer(t *testing.T) {
+	cfg := DefaultConfig()
+	perHostWAF := WAFConfig{}
+	perHostWAF.RateLimit.Enabled = true
+	perHostWAF.RateLimit.Rules = []RateLimitRule{
+		{ID: "vhost-limit", Scope: "ip", Limit: 50, Window: time.Minute, Action: "block"},
+	}
+	cfg.VirtualHosts = []VirtualHostConfig{
+		{
+			Domains: []string{"secure.example.com"},
+			WAF:     &perHostWAF,
+		},
+	}
+
+	out := MarshalYAML(cfg)
+
+	if !strings.Contains(out, "waf:") {
+		t.Errorf("expected 'waf:' block inside virtual_hosts entry (Bug 3 regression); got:\n%s", out)
+	}
+	if !strings.Contains(out, "vhost-limit") {
+		t.Errorf("expected rate limit rule id 'vhost-limit' in output; got:\n%s", out)
+	}
+}


### PR DESCRIPTION
Hi @ersinkoc 

I love this WAF, beautiful and light!
But I got bugs while save config (routes and hosts)in Dashboard

## Problem

When saving configuration via `SaveFile` / `MarshalYAML`, several fields —
`upstreams`, `routes`, and `virtual_hosts` — were either **completely missing**
or had **incorrect indentation** in the output YAML, causing silent data loss
on the next config load.

The root cause was three bugs in `marshalInlineField` in
`internal/config/serialize.go`.

---

## Bug 1 — Nested struct fields written at wrong indentation level

`marshalInlineField` called `marshalStruct` with the same `indent` as the
parent key, so child fields were emitted at the same level as their parent key,
producing structurally invalid YAML.

```yaml
# Before (broken)
upstreams:
  - name: backend
    health_check:
    enabled: true      # ← should be indented under health_check

# After (fixed)
upstreams:
  - name: backend
    health_check:
      enabled: true
      interval: 30s
```

**Fix:** Pass `indent+1` instead of `indent` when calling `marshalStruct`.

---

## Bug 2 — Struct slices inside sequence items silently discarded

The `reflect.Slice` case only handled `[]string` and silently dropped all
other element kinds. Fields like `upstreams[].targets` and
`virtual_hosts[].routes` produced no output at all.

**Fix:** Added `else if elemKind == reflect.Struct` branch that serializes
struct slices in block style.

---

## Bug 3 — Pointer fields inside sequence items silently discarded

`marshalInlineField` had no `reflect.Ptr` case, so `virtual_hosts[].waf`
(`*WAFConfig`) was silently discarded.

**Fix:** Added `reflect.Ptr` case that dereferences non-nil pointers and
recurses.

---

## Tests

Three regression tests added to `internal/config/serialize_test.go`:

| Test | Covers |
|------|--------|
| `TestMarshalYAML_UpstreamTargets` | Bug 1 + Bug 2 (`Targets` struct slice), full roundtrip |
| `TestMarshalYAML_VirtualHostRoutes` | Bug 2 (`Routes` inside `VirtualHosts`), full roundtrip |
| `TestMarshalYAML_VirtualHostWAFPointer` | Bug 3 (`*WAFConfig` pointer field) |
